### PR TITLE
Setup pre-commit hooks for flake8, isort, and black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503
+exclude = 
+    venv,
+    .git,
+    __pycache__,
+    .pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 .pytest_cache/
 .env
 .venv/
+.vscode/
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
This pull request adds and configures pre-commit hooks to enforce consistent code style and quality checks on every commit. Changes include:

- .pre-commit-config.yaml: Added hooks for
- black (automatic code formatting)
- isort (import sorting)
- flake8 (linting)
- .flake8: New configuration file for flake8 rules.
- pyproject.toml: isort and black settings centralized here.
- .gitignore: Now ignores IDE directories (.vscode/, .idea/).

No functional code changes — purely tooling and configuration updates.
Merge into develop.