### PR TITLE
feat(p2359): add solution and tests for “Find Closest Node to Given Two Nodes”

### DIFF
--- a/p2359_find_closest_node/README.md
+++ b/p2359_find_closest_node/README.md
@@ -1,0 +1,74 @@
+# LeetCode #2359: Find Closest Node to Given Two Nodes
+
+## 📖 Problem
+
+You are given a directed graph of `n` nodes numbered from `0` to `n - 1`, where each node has at most one outgoing edge.
+
+The graph is represented with a given 0-indexed array `edges` of size `n`, indicating that there is a directed edge from node `i` to node `edges[i]`. If there is no outgoing edge from `i`, then `edges[i] == -1`.
+
+You are also given two integers `node1` and `node2`.
+
+Return the index of the node that can be reached from both `node1` and `node2`, such that the maximum between the distance from `node1` to that node and from `node2` to that node is minimized. If there are multiple answers, return the node with the smallest index, and if no possible answer exists, return `-1`.
+
+Note that `edges` may contain cycles.
+
+### Example 1
+
+```
+Input: edges = [2,2,3,-1], node1 = 0, node2 = 1
+Output: 2
+Explanation:
+The distance from node 0 to node 2 is 1, and the distance from node 1 to node 2 is 1.
+The maximum of those two distances is 1. It can be proven that we cannot get a node with a smaller maximum distance than 1, so we return node 2.
+```
+
+### Example 2
+
+```
+Input: edges = [1,2,-1], node1 = 0, node2 = 2
+Output: 2
+Explanation:
+The distance from node 0 to node 2 is 2, and the distance from node 2 to itself is 0.
+The maximum of those two distances is 2. It can be proven that we cannot get a node with a smaller maximum distance than 2, so we return node 2.
+```
+
+### Constraints
+
+- `n == edges.length`  
+- `2 <= n <= 10^5`  
+- `-1 <= edges[i] < n`  
+- `edges[i] != i`  
+- `0 <= node1, node2 < n`
+
+## 🚀 Solution (O(n))
+
+1. **Compute distances**  
+   - `dist1 = [INF] * n` — distances from `node1`  
+   - `dist2 = [INF] * n` — distances from `node2`  
+   - Traverse edges from each start until `-1` or revisiting, filling distances.
+
+2. **Select best node**  
+   ```python
+   bestNode, bestCost = -1, INF
+   for i in range(n):
+       if dist1[i] == INF or dist2[i] == INF:
+           continue
+       cost = max(dist1[i], dist2[i])
+       if cost < bestCost or (cost == bestCost and i < bestNode):
+           bestCost, bestNode = cost, i
+   return bestNode
+   ```
+
+## 🔢 Example
+
+```
+edges = [5,4,5,4,3,6,-1]
+node1 = 0
+node2 = 1
+# output -> -1  (no common reachable node)
+```
+
+## 📊 Complexity
+
+- **Time:** O(n) — each node visited at most twice  
+- **Space:** O(n) — two arrays of size n

--- a/p2359_find_closest_node/find_closest_node.py
+++ b/p2359_find_closest_node/find_closest_node.py
@@ -1,0 +1,37 @@
+from typing import List
+
+
+class Solution:
+    def closestMeetingNode(self, edges: List[int], node1: int, node2: int) -> int:
+        n = len(edges)
+        INF = n + 1
+
+        # 1) Compute distances from node1 to all reachable nodes
+        dist1 = [INF] * n
+        cur, d = node1, 0
+        while cur != -1 and dist1[cur] == INF:
+            dist1[cur] = d
+            cur = edges[cur]
+            d += 1
+
+        # 2) Compute distances from node2 to all reachable nodes
+        dist2 = [INF] * n
+        cur, d = node2, 0
+        while cur != -1 and dist2[cur] == INF:
+            dist2[cur] = d
+            cur = edges[cur]
+            d += 1
+
+        # 3) Find the node with minimal max(dist1[i], dist2[i])
+        bestNode = -1
+        bestCost = INF
+        for i in range(n):
+            if dist1[i] == INF or dist2[i] == INF:
+                continue
+            cost = max(dist1[i], dist2[i])
+            if cost < bestCost or (
+                cost == bestCost and (bestNode == -1 or i < bestNode)
+            ):
+                bestCost, bestNode = cost, i
+
+        return bestNode

--- a/p2359_find_closest_node/test_find_closest_node.py
+++ b/p2359_find_closest_node/test_find_closest_node.py
@@ -1,0 +1,17 @@
+import pytest
+
+from p2359_find_closest_node.find_closest_node import Solution
+
+
+@pytest.mark.parametrize(
+    "edges,node1,node2,expected",
+    [
+        ([5, 4, 5, 4, 3, 6, -1], 0, 1, -1),
+        ([2, 2, 3, -1], 0, 1, 2),
+        ([1, -1], 0, 1, 1),
+        ([1, 2, 0], 0, 2, 0),
+        ([1, 2, 3, 4, -1], 0, 2, 2),
+    ],
+)
+def test_closest_meeting_node(edges, node1, node2, expected):
+    assert Solution().closestMeetingNode(edges, node1, node2) == expected


### PR DESCRIPTION
### Summary
- Introduce a new package `p2359_find_closest_node` containing:
  - `find_closest_node.py`: O(n) solution for LeetCode #2359.
  - `test_find_closest_node.py`: pytest suite covering typical and edge cases.
  - `README.md`: problem statement, algorithm overview, and usage instructions.
  - `__init__.py`: package initializer.

### Implementation Details
- Perform two linear traversals to compute distances from `node1` and `node2` to all reachable nodes.
- Perform a single linear scan to select the node that minimizes the maximum of those two distances.
- Use fixed-size lists for distance tracking to minimize overhead and ensure high performance in Python.
- Correctly handles unreachable nodes and cycles.

### Impact
- Fully self-contained; does not modify existing code or CI setup.
- Maintains O(n) time and O(n) space complexity, suitable for inputs up to 10⁵ nodes.