### PR TITLE
feat(p909): add Snakes and Ladders solution, tests, and README

### DIFF
--- a/p909_snakes_and_ladders/README.md
+++ b/p909_snakes_and_ladders/README.md
@@ -1,0 +1,184 @@
+# LeetCode #909: Snakes and Ladders
+
+## 📖 Problem
+
+You are given an `n x n` integer matrix `board` where the cells are labeled from `1` to `n^2` in a Boustrophedon style starting from the bottom-left of the board (`board[n - 1][0]`) and alternating direction each row.
+
+You start on square `1`. In each move, starting from square `curr`, do the following:
+
+1. Choose a destination square `next` with a label in the range `[curr + 1, min(curr + 6, n^2)]`.  
+   - This simulates the result of a standard 6-sided die roll: there are at most 6 possible destinations.
+2. If `next` has a snake or ladder (`board[r][c] != -1` for its coordinates `(r, c)`), you **must** move to `board[r][c]`. Otherwise, you stay on `next`.
+3. The game ends when you reach square `n^2`.
+
+A board square on row `r` and column `c` has a snake or ladder if `board[r][c] != -1`. The destination of that snake or ladder is `board[r][c]`. Squares `1` and `n^2` are not the starting points of any snake or ladder.
+
+Note that you only take a snake or ladder at most once per dice roll. If the destination of a snake or ladder is the start of another snake or ladder, you do **not** follow the subsequent snake or ladder.
+
+Return the least number of dice rolls required to reach square `n^2`. If it is not possible to reach that square, return `-1`.
+
+### Example 1
+
+```
+Input: 
+board = [
+  [-1, -1, -1, -1, -1, -1],
+  [-1, -1, -1, -1, -1, -1],
+  [-1, -1, -1, -1, -1, -1],
+  [-1, 35, -1, -1, 13, -1],
+  [-1, -1, -1, -1, -1, -1],
+  [-1, 15, -1, -1, -1, -1]
+]
+Output: 4
+
+Explanation:
+Boustrophedon labeling (6×6):
+Row 0 (top):      36  35  34  33  32  31
+Row 1:            25  26  27  28  29  30
+Row 2:            24  23  22  21  20  19
+Row 3:            13  14  15  16  17  18
+Row 4:            12  11  10   9   8   7
+Row 5 (bottom):    1   2   3   4   5   6
+
+One optimal sequence:
+- Start at 1.
+- Roll 1 → move to 2, ladder sends you to 15.
+- From 15, roll 2 → move to 17, snake sends you to 13.
+- From 13, roll 1 → move to 14, ladder sends you to 35.
+- From 35, roll 1 → move to 36 (end).
+Total rolls = 4.
+```
+
+### Example 2
+
+```
+Input:
+board = [
+  [-1, -1],
+  [-1,  3]
+]
+Output: 1
+
+Explanation:
+Boustrophedon labeling (2×2):
+Row 1 (bottom):    1   2
+Row 0 (top):       4   3
+From 1, roll 1 → land on 2, ladder sends you to 3 (end). Total rolls = 1.
+```
+
+### Constraints
+
+- `n == board.length == board[i].length`  
+- `2 <= n <= 20`  
+- `board[i][j]` is either `-1` or in the range `[1, n^2]`.  
+- Squares labeled `1` and `n^2` are not the starting points of any snake or ladder.
+
+---
+
+## 🚀 Solution (O(n²))
+
+1. **Handle edge case `n = 1`.**  
+   - If `n == 1`, then `n^2 == 1`, start and end are the same square → return `0`.
+
+2. **Flatten the board into a 1D array `dest[]` of length `n^2 + 1`.**  
+   - Let `n2 = n * n`.  
+   - Create `dest = [0] * (n2 + 1)` and an index `idx = 1`.  
+   - Iterate rows from bottom to top:
+     ```python
+     idx = 1
+     for row in range(n - 1, -1, -1):
+         left_to_right = ((n - 1 - row) % 2 == 0)
+         if left_to_right:
+             for col in range(0, n):
+                 val = board[row][col]
+                 dest[idx] = val if val != -1 else idx
+                 idx += 1
+         else:
+             for col in range(n - 1, -1, -1):
+                 val = board[row][col]
+                 dest[idx] = val if val != -1 else idx
+                 idx += 1
+     ```
+   - After this `O(n²)` pass, `dest[k]` gives the final landing square if you “land” on `k`, following exactly one snake/ladder if present.
+
+3. **Perform BFS over 1D squares (1 to n²).**  
+   - Create an array `dist = [-1] * (n2 + 1)`, set `dist[1] = 0`.  
+   - Use a list `queue = [1]` and a head pointer `head = 0` for `O(1)`-time pops:
+     ```python
+     dist = [-1] * (n2 + 1)
+     dist[1] = 0
+     queue = [1]
+     head = 0
+
+     while head < len(queue):
+         curr = queue[head]
+         head += 1
+         steps = dist[curr]
+
+         for move in range(1, 7):             # simulate die = 1..6
+             nxt = curr + move
+             if nxt > n2:
+                 break                       # beyond n², no valid moves
+             target = dest[nxt]             # apply one snake/ladder
+             if dist[target] == -1:         # not visited yet
+                 dist[target] = steps + 1
+                 if target == n2:
+                     return dist[target]     # reached end in minimal rolls
+                 queue.append(target)
+
+     return -1  # if BFS finishes without reaching n², return -1
+     ```
+   - **Why BFS?** Each dice roll counts as one move of weight=1. BFS finds the minimum number of moves to reach `n^2`.
+
+4. **Return result.**  
+   - If BFS reaches `n2`, return the corresponding `dist[n2]`.  
+   - Otherwise, return `-1`.
+
+---
+
+## 🔢 Example Walkthrough
+
+```
+board = [
+  [-1, -1, -1],
+  [-1,  9,  8],
+  [-1,  6, -1]
+]
+# n = 3, n2 = 9
+# Boustrophedon labeling (3×3):
+#    1    2    3
+#    6    5    4
+#    7    8    9
+# dest mapping:
+#   dest[1] = 1
+#   dest[2] = 9   (ladder)
+#   dest[3] = 3
+#   dest[4] = 4
+#   dest[5] = 5
+#   dest[6] = 6
+#   dest[7] = 7
+#   dest[8] = 8
+#   dest[9] = 9
+#
+# BFS:
+#   dist[1] = 0
+#   queue = [1]
+#   head = 0
+#
+#   Dequeue curr = 1 (steps = 0):
+#     moves: 1+1=2 -> dest[2] = 9 -> dist[9] = 1 -> return 1
+#   Output: 1
+```
+
+## 📊 Complexity
+
+- **Time:**  
+  - Building `dest[]` is `O(n²)`.  
+  - BFS visits each square at most once and checks up to 6 neighbors → `O(6 · n²) = O(n²)`.  
+  - Overall: **O(n²)**.
+
+- **Space:**  
+  - `dest[]` of size `n² + 1`.  
+  - `dist[]` of size `n² + 1`.  
+  - `queue` holds up to `n²` indices in the worst case.  
+  - Overall: **O(n²)**.

--- a/p909_snakes_and_ladders/snakes_and_ladders.py
+++ b/p909_snakes_and_ladders/snakes_and_ladders.py
@@ -1,0 +1,57 @@
+from typing import List
+
+
+class Solution:
+    def snakesAndLadders(self, board: List[List[int]]) -> int:
+        n = len(board)
+        n2 = n * n
+
+        # Special case: if there's only one square, we're already at the end
+        if n2 == 1:
+            return 0
+
+        # 1. Build 1D array `dest` of length (n2 + 1):
+        #    dest[i] = destination square if you land on i (snake/ladder) or i itself.
+        dest = [0] * (n2 + 1)
+        idx = 1
+        for row in range(n - 1, -1, -1):
+            is_left_to_right = (n - 1 - row) % 2 == 0
+            if is_left_to_right:
+                for col in range(0, n):
+                    val = board[row][col]
+                    dest[idx] = val if val != -1 else idx
+                    idx += 1
+            else:
+                for col in range(n - 1, -1, -1):
+                    val = board[row][col]
+                    dest[idx] = val if val != -1 else idx
+                    idx += 1
+
+        # 2. Initialize distances array: dist[i] = -1 means "unvisited".
+        dist = [-1] * (n2 + 1)
+        dist[1] = 0  # Start at square 1 with 0 moves
+
+        # 3. Use a Python list as a queue with head pointer for O(1) pop from front
+        queue = [1]
+        head = 0
+
+        # 4. Standard BFS loop
+        while head < len(queue):
+            curr = queue[head]
+            head += 1
+            moves = dist[curr]
+
+            # Try dice rolls from 1 to 6
+            for step in range(1, 7):
+                nxt = curr + step
+                if nxt > n2:
+                    break
+                target = dest[nxt]
+                if dist[target] == -1:
+                    dist[target] = moves + 1
+                    if target == n2:
+                        return dist[target]
+                    queue.append(target)
+
+        # 5. If BFS finished without reaching n2, it's unreachable
+        return -1

--- a/p909_snakes_and_ladders/test_snakes_and_ladders.py
+++ b/p909_snakes_and_ladders/test_snakes_and_ladders.py
@@ -1,0 +1,132 @@
+from typing import List
+
+import pytest
+
+from p909_snakes_and_ladders.snakes_and_ladders import Solution
+
+
+@pytest.mark.parametrize(
+    "board, expected",
+    [
+        # 1x1 board: only one square (start and end), no moves needed
+        ([[-1]], 0),
+        # 2x2 board without snakes or ladders:
+        # Boustrophedon numbering:
+        #   (1)  (2)
+        #   (4)  (3)
+        # You can roll a 3 from 1 → 4 in one move.
+        (
+            [
+                [-1, -1],
+                [-1, -1],
+            ],
+            1,
+        ),
+        # 2x2 board with a ladder from 2 -> 4:
+        # From 1, roll 1 -> land on 2 -> ladder to 4 = 1 move
+        (
+            [
+                [-1, 4],
+                [-1, -1],
+            ],
+            1,
+        ),
+        # 3x3 board without snakes or ladders:
+        # Boustrophedon numbering:
+        #    1   2   3
+        #    6   5   4
+        #    7   8   9
+        # Minimum number of moves = ceil((9 - 1) / 6) = 2
+        (
+            [
+                [-1, -1, -1],
+                [-1, -1, -1],
+                [-1, -1, -1],
+            ],
+            2,
+        ),
+        # 3x3 board with a snake cycle (still reachable in 2 moves):
+        # board:
+        #   row 2 -> [-1,  3,  2]
+        # means: cell2 -> 3, cell3 -> 2 (cycle).
+        # But from 1: roll 1->2->ladder to 3 (1 move),
+        # then roll 6 -> 9 (2nd move). So answer = 2.
+        (
+            [
+                [-1, -1, -1],
+                [-1, -1, -1],
+                [-1, 3, 2],
+            ],
+            2,
+        ),
+        # 4x4 board with a ladder 3 -> 15 and a snake 14 -> 4:
+        # Boustrophedon numbering:
+        #    1    2    3    4
+        #    8    7    6    5
+        #    9   10   11   12
+        #   16   15   14   13
+        # Path: from 1 roll 2 -> land on 3 -> ladder to 15 (1 move),
+        # then roll 1 -> land on 16 (2nd move) => 2.
+        (
+            [
+                [-1, -1, -1, -1],
+                [-1, -1, -1, -1],
+                [-1, -1, -1, 4],
+                [-1, 15, -1, -1],
+            ],
+            2,
+        ),
+        # 4x4 board with a ladder 2 -> 16 (end):
+        # To make cell #2 point to 16, we place 16 at (row=3, col=1).
+        # Boustrophedon numbering (row=3 is bottom):
+        #    (1)  (2)  (3)   (4)
+        #    (8)  (7)  (6)   (5)
+        #    (9) (10) (11)  (12)
+        #   (16) (15) (14)  (13)
+        # From 1, roll 1 -> land on 2, ladder to 16: 1 move total.
+        (
+            [
+                [-1, -1, -1, -1],
+                [-1, -1, -1, -1],
+                [-1, -1, -1, -1],
+                [-1, 16, -1, -1],
+            ],
+            1,
+        ),
+        # 5x5 board without snakes or ladders:
+        # Boustrophedon numbering, no shortcuts:
+        # Minimum moves = ceil((25 - 1) / 6) = 4
+        (
+            [
+                [-1, -1, -1, -1, -1],
+                [-1, -1, -1, -1, -1],
+                [-1, -1, -1, -1, -1],
+                [-1, -1, -1, -1, -1],
+                [-1, -1, -1, -1, -1],
+            ],
+            4,
+        ),
+        # 5x5 board with a ladder 4 -> 22:
+        # Boustrophedon numbering:
+        #    (1)  (2)  (3)  (4)   (5)
+        #    (10) (9)  (8)  (7)   (6)
+        #    (11) (12) (13) (14)  (15)
+        #    (20) (19) (18) (17)  (16)
+        #    (21) (22) (23) (24)  (25)
+        # Ladder placed so that cell #4 maps to 22. From 1:
+        # roll 3 -> land on 4 -> ladder to 22 (1 move),
+        # then roll 3 -> land on 25 (2nd move) => 2.
+        (
+            [
+                [-1, -1, -1, -1, -1],
+                [-1, -1, -1, -1, -1],
+                [-1, -1, -1, -1, -1],
+                [-1, -1, -1, -1, -1],
+                [-1, -1, -1, 22, -1],
+            ],
+            2,
+        ),
+    ],
+)
+def test_snakes_and_ladders(board: List[List[int]], expected: int):
+    assert Solution().snakesAndLadders(board) == expected


### PR DESCRIPTION
### Summary
- Introduce a new package `p909_snakes_and_ladders` containing:
  - `snakes_and_ladders.py`: O(n²) BFS-based solution for LeetCode #909.
  - `test_snakes_and_ladders.py`: pytest suite covering example, edge cases, and cycles.
  - `README.md`: problem statement, flattened-board explanation, and usage instructions.
  - `__init__.py`: package initializer.

### Implementation Details
- **Flatten board to 1D (`dest[]`):**  
  - Precompute `dest[i]` for each square `i` in `[1..n²]`.  
  - If `board[r][c] != -1`, set `dest[i] = board[r][c]` (snake/ladder target), otherwise `dest[i] = i`.  
  - This one-time `O(n²)` pass eliminates repeated 2D indexing and direction checks during BFS.

- **BFS on 1D indices (1..n²):**  
  - Maintain `dist[i] = -1` (unvisited) or “min rolls to reach i.” Set `dist[1] = 0`.  
  - Use a Python list `queue = [1]` with a head pointer for O(1)-time pops.  
  - For each `curr` dequeued, for `move in 1..6`, compute `nxt = curr + move`; if `nxt ≤ n²`, map to `target = dest[nxt]`, then if `dist[target] == -1` assign `dist[target] = dist[curr] + 1` and enqueue.  
  - Return `dist[n²]` upon first reach, or `-1` if unreachable.

- **Edge Case `n = 1`:**  
  - Immediately return `0`, since the start and end square coincide.